### PR TITLE
fix(options): typeerror when trying options from storage

### DIFF
--- a/src/ext/content.ts
+++ b/src/ext/content.ts
@@ -46,7 +46,7 @@ const keys = {
 const bindKeys = async () => {
   const sync = await browser.storage.sync.get();
   for (const name of Object.keys(keys)) {
-    const hotkey = sync[name] ?? keys[name as keyof typeof keys];
+    const hotkey = sync.keys?.[name] ?? keys[name as keyof typeof keys];
     let sum = 0;
     for (const mod of hotkey.match(/<[a-zA-Z]+>/g) ?? []) {
       switch (mod.substring(1, mod.length - 1).toLowerCase()) {

--- a/src/settings/options.ts
+++ b/src/settings/options.ts
@@ -38,7 +38,7 @@ browser.storage.sync.get().then((sync) => {
   for (const el of document.querySelectorAll("input, textarea")) {
     const [section, name] = el.getAttribute("data-value")!.split(".");
     (el as HTMLInputElement).value =
-      (sync as any)[section][name] ?? (presets as any)[section][name];
+      (sync as any)[section]?.[name] ?? (presets as any)[section][name];
   }
 });
 


### PR DESCRIPTION
I created a chrome-wrapper for your amazing mouseless rework and noticed this little bug while working on the settings feature.